### PR TITLE
chore: Switch to use private config hub service

### DIFF
--- a/yocto_build_config.env
+++ b/yocto_build_config.env
@@ -1,3 +1,3 @@
 DEBUG_TWEAKS_ENABLED=1
 INCLUDE_RCLONE=0
-INIT_CONFIG_URL=http://hub-atls.builder.flashbots.net
+INIT_CONFIG_URL=https://hub-atls.builder.flashbots.net

--- a/yocto_build_config.env
+++ b/yocto_build_config.env
@@ -1,3 +1,3 @@
 DEBUG_TWEAKS_ENABLED=1
 INCLUDE_RCLONE=0
-CLOUD_INIT_CONFIG_URL=http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text
+INIT_CONFIG_URL=http://hub-atls.builder.flashbots.net


### PR DESCRIPTION
to keep track with the correct yocto build environment variables