### PR TITLE
Bob V2.3: Pectra + Logrotate

### DIFF
--- a/tdx-bob.xml
+++ b/tdx-bob.xml
@@ -13,10 +13,10 @@
   <project remote="flashbots"       revision="4a7bb77f7ebe0ac8be5bab5103d8bd993e17e18d"        name="meta-openembedded"               path="srcs/poky/meta-openembedded"/>
   <project remote="flashbots"       revision="adbc1d929c4470c260464215b80f3968ea6d4564"        name="meta-secure-core"                path="srcs/poky/meta-secure-core"/>
   <project remote="flashbots"       revision="54b806b1985f3989722ee308e1073530fe3328c1"        name="meta-virtualization"             path="srcs/poky/meta-virtualization"/>
-  <project remote="flashbots"       revision="f1b1770d80946ea8d879632a8d572dacadb3edc4"        name="meta-confidential-compute"       path="srcs/poky/meta-confidential-compute"/>
+  <project remote="flashbots"       revision="d8bcb394310f896f98f8b83b29732678792d101e"        name="meta-confidential-compute"       path="srcs/poky/meta-confidential-compute"/>
   <project remote="flashbots"       revision="fe228e989d9eb7006662db805c1c47db4aee8db3"        name="meta-custom-podman"              path="srcs/poky/meta-custom-podman"/>
-  <project remote="flashbots"       revision="e3e972b394ae726edd6b1febc19bf9383f537545"        name="meta-searcher"                   path="srcs/poky/meta-searcher"/>
-  <project remote="flashbots"       revision="061d78b05f2afb995d2d8f0cf7f403b14f89c92a"        name="meta-rust-bin"                   path="srcs/poky/meta-rust-bin"/>
+  <project remote="flashbots"       revision="b800b9a238e691ced269695d90ecd663b82f9d68"        name="meta-searcher"                   path="srcs/poky/meta-searcher"/>
+  <project remote="flashbots"       revision="7942f38efeee429ffc26c60bcd33d1435bda1c1e"        name="meta-rust-bin"                   path="srcs/poky/meta-rust-bin"/>
   <project remote="flashbots"       revision="f002eb5ab051443e7b5fbc32a9505d63a67db7b6"        name="meta-clang"                      path="srcs/poky/meta-clang"/>
 
 </manifest>


### PR DESCRIPTION
- meta-confidential-compute: updates to latest confidential compute commit to include the logrotate fix
- meta-searcher: upgrade lighthouse version from v5.3.0 to v7.0.1
- meta-rust-bin: updates rust version (lighthouse dependency)